### PR TITLE
Correct include dir for xtanswer.h

### DIFF
--- a/src/chpixfile/mkpkg
+++ b/src/chpixfile/mkpkg
@@ -6,5 +6,5 @@ $checkin	libpkg.a ../
 $exit
 
 libpkg.a:
-	t_chpixfile.x	<chars.h> <error.h> <xtools$xtanswer.h>
+	t_chpixfile.x	<chars.h> <error.h> <pkg/xtanswer.h>
 	;

--- a/src/chpixfile/t_chpixfile.x
+++ b/src/chpixfile/t_chpixfile.x
@@ -1,6 +1,6 @@
 include	<chars.h>
 include	<error.h>
-include	<xtools$xtanswer.h>
+include	<pkg/xtanswer.h>
 
 # Strings used to flag the use of the the same node and image directory
 # specified in the image header.


### PR DESCRIPTION
In IRAF, the two files `xtools$xtanswer.h` and `pkg/xtanswer.h` are identical. However, only the one in `pkg` should be used to define the interface, and `xtools` is not defined as a variable. So, we use the `pkg` one here (as elsewhere in ctio).