### PR TITLE
Use mkfloat in mkpkg

### DIFF
--- a/mkpkg
+++ b/mkpkg
@@ -32,7 +32,7 @@ summary:
 arch:					# show current float option
 showfloat:
 	$verbose off
-	!$(hlib)/mkfloat.csh
+	!$(hlib)/mkfloat
 	;
 generic:				# generic installation (no bin)
 	$ifnfile (bin.generic)
@@ -40,7 +40,7 @@ generic:				# generic installation (no bin)
 	$endif
 	$verbose off
 	$set DIRS = "lib src fabry spcombine"
-	!$(hlib)/mkfloat.csh generic -d $(DIRS)
+	!$(hlib)/mkfloat generic -d $(DIRS)
 	;
 
 freebsd:                                # install FreeBSD binaries
@@ -49,7 +49,7 @@ freebsd:                                # install FreeBSD binaries
 	$endif
         $verbose off
         $set DIRS = "lib src fabry spcombine"
-        !$(hlib)/mkfloat.csh freebsd -d $(DIRS)
+        !$(hlib)/mkfloat freebsd -d $(DIRS)
         ;
 linux:                                  # install Slackwkare Linux binaries
 	$ifnfile (bin.linux)
@@ -57,7 +57,7 @@ linux:                                  # install Slackwkare Linux binaries
 	$endif
         $verbose off
         $set DIRS = "lib src fabry spcombine"
-        !$(hlib)/mkfloat.csh linux -d $(DIRS)
+        !$(hlib)/mkfloat linux -d $(DIRS)
         ;
 linux64:                                # install x86_64 binaries
 	$ifnfile (bin.linux64)
@@ -65,7 +65,7 @@ linux64:                                # install x86_64 binaries
 	$endif
         $verbose off
         $set DIRS = "lib src fabry spcombine"
-        !$(hlib)/mkfloat.csh linux64 -d $(DIRS)
+        !$(hlib)/mkfloat linux64 -d $(DIRS)
         ;
 macosx:                                 # install Mac OS X (PPC) binaries
 	$ifnfile (bin.macosx)
@@ -73,7 +73,7 @@ macosx:                                 # install Mac OS X (PPC) binaries
 	$endif
         $verbose off
         $set DIRS = "lib src fabry spcombine"
-        !$(hlib)/mkfloat.csh macosx -d $(DIRS)
+        !$(hlib)/mkfloat macosx -d $(DIRS)
         ;
 macintel:                               # install Mac OS X (Intel) binaries
 	$ifnfile (bin.macintel)
@@ -81,7 +81,7 @@ macintel:                               # install Mac OS X (Intel) binaries
 	$endif
         $verbose off
         $set DIRS = "lib src fabry spcombine"
-        !$(hlib)/mkfloat.csh macintel -d $(DIRS)
+        !$(hlib)/mkfloat macintel -d $(DIRS)
         ;
 cygwin:                                 # install Cygwin binaries
 	$ifnfile (bin.cygwin)
@@ -89,7 +89,7 @@ cygwin:                                 # install Cygwin binaries
 	$endif
         $verbose off
         $set DIRS = "lib src fabry spcombine"
-        !$(hlib)/mkfloat.csh cygwin -d $(DIRS)
+        !$(hlib)/mkfloat cygwin -d $(DIRS)
         ;
 redhat:                                 # install Redhat Linux binaries
 	$ifnfile (bin.redhat)
@@ -97,7 +97,7 @@ redhat:                                 # install Redhat Linux binaries
 	$endif
         $verbose off
         $set DIRS = "lib src fabry spcombine"
-        !$(hlib)/mkfloat.csh redhat -d $(DIRS)
+        !$(hlib)/mkfloat redhat -d $(DIRS)
         ;
 sparc:					# install sparc binaries
 	$ifnfile (bin.sparc)
@@ -105,7 +105,7 @@ sparc:					# install sparc binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src fabry spcombine"
-	!$(hlib)/mkfloat.csh sparc -d $(DIRS)
+	!$(hlib)/mkfloat sparc -d $(DIRS)
 	;
 ssun:					# install Sun/Solaris binaries
 	$ifnfile (bin.ssun)
@@ -113,7 +113,7 @@ ssun:					# install Sun/Solaris binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src fabry spcombine"
-	!$(hlib)/mkfloat.csh ssun -d $(DIRS)
+	!$(hlib)/mkfloat ssun -d $(DIRS)
 	;
 sunos:                                  # install SunOS (Solaris x86) binaries
 	$ifnfile (bin.sunos)
@@ -121,5 +121,5 @@ sunos:                                  # install SunOS (Solaris x86) binaries
 	$endif
         $verbose off
         $set DIRS = "lib src fabry spcombine"
-        !$(hlib)/mkfloat.csh sunos -d $(DIRS)
+        !$(hlib)/mkfloat sunos -d $(DIRS)
         ;


### PR DESCRIPTION
IRAF now uses /bin/sh compatible scripts instead of (t)csh. Since the shell name was encoded in the suffix, this needs to be changed in `mkpkg`.

Reference: iraf-community/iraf#87